### PR TITLE
Require subr-x at compile time

### DIFF
--- a/parsebib.el
+++ b/parsebib.el
@@ -41,7 +41,7 @@
 
 (require 'bibtex)
 (require 'cl-lib)
-(require 'subr-x) ; for `string-join'.
+(eval-when-compile (require 'subr-x)) ; for `string-join'.
 
 (defvar parsebib--biblatex-inheritances '(("all"
                                    "all"


### PR DESCRIPTION
`string-join' is an inline function so we only need subr-x at compile
time, not run time.