### PR TITLE
`parsebib--get-xref-fields`: use all matching biblatex rules

### DIFF
--- a/parsebib.el
+++ b/parsebib.el
@@ -311,12 +311,17 @@ such an inheritance schema."
   (when (and target-entry source-entry)
     (when (eq inheritance 'biblatex)
       (setq inheritance parsebib--biblatex-inheritances))
-    (let* ((inheritable-fields (unless (eq inheritance 'BibTeX)
-                                 (append (cl-third (cl-find-if (lambda (elem)
-                                                                 (and (string-match-p (concat "\\b" (cdr (assoc-string "=type=" source-entry)) "\\b") (cl-first elem))
-                                                                      (string-match-p (concat "\\b" (cdr (assoc-string "=type=" target-entry)) "\\b") (cl-second elem))))
-                                                               inheritance))
-                                         (cl-third (assoc-string "all" inheritance)))))
+    (let* ((inheritable-fields
+            (unless (eq inheritance 'BibTeX)
+              (append
+               (mapcan #'cl-third (cl-remove-if-not
+                                   (lambda (elem)
+                                     (and (string-match-p (concat "\\b" (cdr (assoc-string "=type=" source-entry)) "\\b")
+                                                          (cl-first elem))
+					  (string-match-p (concat "\\b" (cdr (assoc-string "=type=" target-entry)) "\\b")
+                                                          (cl-second elem))))
+                                   inheritance))
+               (cl-third (assoc-string "all" inheritance)))))
            (new-fields (delq nil (mapcar (lambda (field)
                                            (let ((target-field (parsebib--get-target-field (car field) inheritable-fields)))
                                              (if (and target-field


### PR DESCRIPTION
The current code in `parsebib--get-xref-fields` finds and applies only the first specific biblatex inheritance rule that matches the given source and target but there are cases when several rules match and have to be applied, e.g., in the case of `book` -> `inbook` inheritance, where title field inheritance is described in the second matching default rule. This PR changes to code to collect (and apply) all matching rules instead of only the first one.