### PR TITLE
`parsebib--get-xref-fields`: don't mutate inheritance rules

### DIFF
--- a/parsebib.el
+++ b/parsebib.el
@@ -314,13 +314,14 @@ such an inheritance schema."
     (let* ((inheritable-fields
             (unless (eq inheritance 'BibTeX)
               (append
-               (mapcan #'cl-third (cl-remove-if-not
-                                   (lambda (elem)
-                                     (and (string-match-p (concat "\\b" (cdr (assoc-string "=type=" source-entry)) "\\b")
-                                                          (cl-first elem))
-					  (string-match-p (concat "\\b" (cdr (assoc-string "=type=" target-entry)) "\\b")
-                                                          (cl-second elem))))
-                                   inheritance))
+               (apply #'append (mapcar #'cl-third
+				       (cl-remove-if-not
+					(lambda (elem)
+					  (and (string-match-p (concat "\\b" (cdr (assoc-string "=type=" source-entry)) "\\b")
+							       (cl-first elem))
+					       (string-match-p (concat "\\b" (cdr (assoc-string "=type=" target-entry)) "\\b")
+							       (cl-second elem))))
+					inheritance)))
                (cl-third (assoc-string "all" inheritance)))))
            (new-fields (delq nil (mapcar (lambda (field)
                                            (let ((target-field (parsebib--get-target-field (car field) inheritable-fields)))


### PR DESCRIPTION
*Apologies*, I've just realized that the change in my previous PR used a mutating function (`mapcan`) to assemble the inheritable fields list, which could potentially lead to grave errors. The current PR replaces the function with a side-effect free construct. Thanks and sorry again for this mistake and inconvenience. 