### PR TITLE
Swap obsolete point-at-eol for line-end-position

### DIFF
--- a/parsebib.el
+++ b/parsebib.el
@@ -631,7 +631,7 @@ point."
       (if (looking-at-p "[[:space:]]*[\(\{]")
           (progn (skip-chars-forward "[:space:]")
                  (parsebib--match-paren-forward))
-        (goto-char (point-at-eol)))
+        (goto-char (line-end-position)))
       (buffer-substring-no-properties beg (point)))))
 
 (defun parsebib-read-string (&optional pos strings)


### PR DESCRIPTION
The `point-at-eol` function is (will be) obsolete as of Emacs 29.1, so this replaces it with `line-end-position`.

Fix #28